### PR TITLE
Make pandoc.to detection more robust

### DIFF
--- a/inst/skeleton/ms.Rmd
+++ b/inst/skeleton/ms.Rmd
@@ -32,8 +32,8 @@ header-includes:
 ---
 
 ```{r setup, include=FALSE}
-is_docx <- knitr::opts_knit$get("rmarkdown.pandoc.to") == 'docx'
-is_latex <- knitr::opts_knit$get("rmarkdown.pandoc.to") == 'latex'
+is_docx <- knitr::pandoc_to("docx")
+is_latex <- knitr::pandoc_to("latex")
 
 # I don't know how Texas Instruments smart this is, but p-sure default DPI is 96.
 # That's not a problem for LaTeX, but it looks not-so-great for Word.


### PR DESCRIPTION
`knitr::opts_knit$get("rmarkdown.pandoc.to")` works fine when knitting, but when running interactively, it returns `logical(0)` and breaks lots of the logic that depends on `is_docx` or `is_latex` being true or false. The `pandoc_to()` function in knitr always returns true or false, though, so it works both when knitting and when working interactively

```r
is_latex <- knitr::opts_knit$get("rmarkdown.pandoc.to") == "latex"
is_latex
#> logical(0)

is_latex <- knitr::pandoc_to("latex")
is_latex
#> [1] FALSE
```